### PR TITLE
Clone and partialeq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "pubserve"
-version = "1.1.0-alpha.1"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubserve"
 license = "MPL-2.0"
-version = "1.1.0-alpha.1"
+version = "1.1.0"
 edition = "2021"
 authors = ["bitfl0wer <flori@polyphony.chat>"]
 description = "Simple, generic observer trait."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub trait Subscriber<T> {
 /// let mut publisher = Publisher::<String>::new();
 /// publisher.publish("Hello, World!".to_string()); // .await, if async feature is enabled
 /// ```
+#[derive(Clone)]
 pub struct Publisher<T> {
     subscribers: Vec<ReferenceCounted<dyn Subscriber<T>>>,
 }
@@ -65,6 +66,19 @@ impl<T> Debug for Publisher<T> {
         f.debug_struct("Publisher")
             .field("subscribers", &self.subscribers.len())
             .finish()
+    }
+}
+
+impl<T> PartialEq for Publisher<T> {
+    fn eq(&self, other: &Self) -> bool {
+        for (own_subscriber, other_subscriber) in
+            self.subscribers.iter().zip(other.subscribers.iter())
+        {
+            if !ReferenceCounted::ptr_eq(own_subscriber, other_subscriber) {
+                return false;
+            }
+        }
+        true
     }
 }
 

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#[cfg(not(feature = "async"))]
+#[test]
+fn test_clone() {
+    use std::cell::RefCell;
+
+    use pubserve::{Publisher, ReferenceCounted, Subscriber};
+
+    struct MySubscriber {
+        vec: RefCell<Vec<i32>>,
+    }
+
+    impl Subscriber<i32> for MySubscriber {
+        fn update(&self, message: &i32) {
+            self.vec.borrow_mut().push(*message);
+            dbg!(self.vec.borrow());
+        }
+    }
+
+    let mut publisher = Publisher::<i32>::new();
+    let shared = ReferenceCounted::new(MySubscriber {
+        vec: RefCell::new(Vec::new()),
+    });
+    publisher.subscribe(shared.clone());
+    publisher.publish(42);
+    assert!(shared.vec.borrow().contains(&42));
+    // Test, if cloning the publisher, then dropping the original publisher, still allows the
+    // subscriber to receive messages.
+    let publisher_clone = publisher.clone();
+    drop(publisher);
+    publisher_clone.publish(43);
+    assert!(shared.vec.borrow().contains(&43));
+}


### PR DESCRIPTION
This Pr adds the `Clone` derive and a manual implementation of the `PartialEq` trait to `Publisher<T>`. The `Clone` derive has had a test written for it to verify that it works as expected (i.e. cloning the Publisher and then publishing using the cloned publisher *still* notifies all the original subscribers).